### PR TITLE
Fix typos and add link checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Afrocursos Site
+
+Este repositório contém as páginas estáticas do site **Afrocursos**.
+
+## Abrindo as Páginas
+
+Abra qualquer arquivo `pagina*.html` em seu navegador. Cada página possui links para os cursos armazenados na pasta `cursos/`.
+
+## Executando os testes
+
+É possível validar automaticamente se todos os links de cursos apontam para arquivos existentes. Para rodar os testes, execute:
+
+```bash
+python -m unittest discover -s tests
+```
+
+Os testes estão localizados em `tests/test_links.py`.

--- a/pagina1.html
+++ b/pagina1.html
@@ -31,7 +31,7 @@
 <div class="curso">
   <img src="imagens/cursos/Bora Vender em Dólar.jpg" alt="Bora Vender em Dólar">
   <h2>Bora Vender em Dólar</h2>
-  <a class="btn" href="cursos/bora-vender-em-dólar">Informações</a>
+  <a class="btn" href="cursos/bora-vender-em-dólar.html">Informações</a>
 </div>
 
 <div class="curso">

--- a/pagina2.html
+++ b/pagina2.html
@@ -12,12 +12,12 @@
     <div class="curso">
       <img src="imagens/cursos/Curso de Automaquiagem.jpg" alt="Curso de Automaquiagem">
       <h2>Curso de Automaquiagem</h2>
-      <a class="btn" href="cursos/curso-de-automaquiagem">Informações</a>
+      <a class="btn" href="cursos/curso-de-automaquiagem.html">Informações</a>
     </div>
     <div class="curso">
       <img src="imagens/cursos/Curso de Inglês Completo Ci Locatelli 2.0.jpg" alt="Curso de Inglês Completo Ci Locatelli 2.0">
       <h2>Curso de Inglês Completo Ci Locatelli 2.0</h2>
-      <a class="btn" href="cursos/curso-de-inglês-completo-ci-locatelli-2.0">Informações</a>
+      <a class="btn" href="cursos/curso-de-inglês-completo-ci-locatelli-2.0.html">Informações</a>
     </div>
     <div class="curso">
       <img src="imagens/cursos/Curso de Manicure e Pedicure Iniciante.jpg" alt="Curso de Manicure e Pedicure Iniciante">

--- a/pagina3.html
+++ b/pagina3.html
@@ -15,8 +15,8 @@
       <a class="btn" href="#">Informações</a>
     </div>
     <div class="curso">
-      <img src="imagens/cursos/Frajola Oficina do Trader.jpg" alt="Frajoia Oficina do Trader">
-      <h2>Frajoia Oficina do Trader</h2>
+      <img src="imagens/cursos/Frajola Oficina do Trader.jpg" alt="Frajola Oficina do Trader">
+      <h2>Frajola Oficina do Trader</h2>
       <a class="btn" href="#">Informações</a>
     </div>
     <div class="curso">

--- a/pagina4.html
+++ b/pagina4.html
@@ -15,7 +15,7 @@
       <a class="btn" href="#">Informações</a>
     </div>
     <div class="curso">
-      <img src="imagens/cursos/Mestre dos Jingles Lucrativos.jpg" alt="Mestre dos Jingles Lucrativos.jpg">
+      <img src="imagens/cursos/Mestre dos Jingles Lucrativos.jpg" alt="Mestre dos Jingles Lucrativos">
       <h2>Mestre dos Jingles Lucrativos</h2>
       <a class="btn" href="#">Informações</a>
     </div>

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1,0 +1,17 @@
+import unittest
+import os
+import re
+import glob
+
+class TestCourseLinks(unittest.TestCase):
+    def test_course_links_exist(self):
+        pattern = re.compile(r'href="cursos/([^"#]+\.html)"')
+        for page in glob.glob('pagina*.html'):
+            with open(page, encoding='utf-8') as f:
+                content = f.read()
+            for target in pattern.findall(content):
+                path = os.path.join('cursos', target)
+                self.assertTrue(os.path.isfile(path), f"{page}: {target} not found")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- correct broken course links in `pagina1.html` and `pagina2.html`
- fix typo "Frajoia" in `pagina3.html`
- adjust `alt` text on page 4
- add automated test checking HTML links
- document how to run the tests in a new README

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_684c2e7ec1688324b602aa17f8bc43bf